### PR TITLE
Publish prerelease yak package from CI build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,7 @@
 /obj
 /.vs
 /packages
+
+# yak deploy
+dist
+script/yak.exe

--- a/GhCanvasViewportInfo.cs
+++ b/GhCanvasViewportInfo.cs
@@ -23,6 +23,15 @@ namespace GhCanvasViewport
                 return "GhCanvasViewport";
             }
         }
+        public override string Version
+        {
+            get
+            {
+                // use AssemblyInformationalVersion since this can be patched easily during CI builds
+                // to keep it in sync with the yak package version
+                return System.Diagnostics.FileVersionInfo.GetVersionInfo(System.Reflection.Assembly.GetExecutingAssembly().Location).ProductVersion;
+            }
+        }
         public override Bitmap Icon
         {
             get

--- a/Properties/AssemblyInfo.cs
+++ b/Properties/AssemblyInfo.cs
@@ -31,6 +31,6 @@ using System.Runtime.InteropServices;
 //
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
-// [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.0.0.0")]
-[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyVersion("1.0.*")]
+//[assembly: AssemblyFileVersion("1.0.0.0")]
+[assembly: AssemblyInformationalVersion("1.0.0-dev")]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,5 +1,5 @@
 # version format
-version: 1.0.{build}
+version: '{build}' # prefer not to use the version number for the build number
 
 # branches to build
 branches:
@@ -7,9 +7,15 @@ branches:
   only:
     - master
 
+# environment variables
+environment:
+  # current major.minor.patch version number
+  assembly_version: '1.0.0'
+  # package version with prerelease identifiers
+  yak_package_version: $(assembly_version)-dev.$(appveyor_build_number)
+
 # Maximum number of concurrent jobs for the project
 max_jobs: 1
-
 
 # Build worker image (VM template)
 image: Visual Studio 2017
@@ -22,10 +28,21 @@ configuration: Release
 
 before_build:
   - nuget restore
-  
+
 build:
   parallel: true                  # enable MSBuild parallel builds
   project: GhCanvasViewport.sln      # path to Visual Studio solution or project
 
   # MSBuild verbosity level
   verbosity: normal
+
+# patch assembly info
+assembly_info:
+  patch: true
+  file: 'Properties\AssemblyInfo.cs'
+  assembly_version: $(assembly_version) # required, otherwise defaults to $(appveyor_build_version)
+  assembly_informational_version: $(yak_package_version)
+
+# publish prerelease build to yak (master only)
+deploy_script:
+  - ps: if ($env:appveyor_repo_branch -eq 'master') {.\script\deploy.ps1}

--- a/dist/manifest.yml
+++ b/dist/manifest.yml
@@ -1,0 +1,9 @@
+---
+name: GhCanvasViewport
+version: 1.0.0-dev
+authors:
+- Steve Baer
+description: Rhino viewport control embedded in the Grasshopper canvas
+url: https://github.com/mcneel/GhCanvasViewport
+secret:
+  id: 406bd915-c42a-4f97-8ce4-4934600b43ff

--- a/script/deploy.ps1
+++ b/script/deploy.ps1
@@ -1,0 +1,30 @@
+# script/deploy.ps1: Create a yak package and push it to the server
+
+$ErrorActionPreference = "Stop" # exit on error
+
+Push-Location
+cd (Split-Path $MyInvocation.MyCommand.Path)
+
+# set version
+$dist = '..\dist'
+$file = "$dist\manifest.yml"
+(Get-Content $file) -replace "version:\s*\S+", "version: $env:yak_package_version" | Set-Content $file
+
+# copy .gha to dist/
+# TODO: make script generic by moving files to command line args?
+Copy-Item -Path ..\bin\GhCanvasViewport.gha -Destination $dist
+
+# zip (create package manually)
+Compress-Archive -Path $dist\* -DestinationPath $dist\build.zip -Force
+
+# get yak.exe
+$url = 'http://files.mcneel.com/yak/tools/latest/yak.exe'
+$yak = '.\yak.exe'
+# Write-Host (New-Object System.Net.WebClient).DownloadFile($url, $yak) # not working
+Invoke-WebRequest -Uri $url -OutFile $yak
+
+# publish
+& $yak version
+& $yak push $dist\build.zip
+
+Pop-Location


### PR DESCRIPTION
Adds a manifest.yml file and a powershell script which sets the version,
zips up the package and pushes it to the yak server.

Patches AssemblyInformationalVersion and tweaks the GhCanvasViewportInfo
class to use the AssemblyInformationalVersion for its Version property.
Since AssemblyInfo patching is easy to do with appveyor, this seems like
a good way to inject a semantic version string (inc. prerelease
identifier and build number) into the version that is read by
Grasshopper. It's important for the Version property to be kept in sync
with the package version for package restore to function properly.

Downloads an 'ilmerged' release of yak.exe (v0.5) to do the pushing.

Deployments happen on the `master` branch only.

See YAK-127