### PR TITLE
Change scroll wheel behaviour

### DIFF
--- a/CanvasViewportControl.cs
+++ b/CanvasViewportControl.cs
@@ -48,6 +48,13 @@ namespace GhCanvasViewport
             }
             RightMouseDownLocation = System.Drawing.Point.Empty;
         }
+        
+        protected override void OnMouseWheel(MouseEventArgs e)
+        {
+            Rhino.Geometry.Vector3d vec = Viewport.CameraDirection;
+            Viewport.SetCameraLocation(Viewport.CameraLocation + vec * e.Delta,false);
+            Refresh();
+        }
 
         void ShowContextMenu(System.Drawing.Point location)
         {


### PR DESCRIPTION
Default behaviour changes lens length, which creates weird stretching effects when zooming out a lot. Instead, move the camera position with scroll wheel, which is more in line with how native Rhino viewports work. Amount of camera movements probably needs finer tweaks tho.

this solves #10 