### PR TITLE
Updates for Rhino 8 with .NET 7

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,32 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Rhino 6 Windows",
+            "type": "clr",
+            "request": "launch",
+            "targetArchitecture": "x86_64",
+            "program": "C:\\Program Files\\Rhino 6\\System\\Rhino.exe",
+            "cwd": "${workspaceRoot}",
+        },
+        {
+            "name": "Rhino 7 Windows",
+            "type": "clr",
+            "request": "launch",
+            "targetArchitecture": "x86_64",
+            "program": "C:\\Program Files\\Rhino 7\\System\\Rhino.exe",
+            "cwd": "${workspaceRoot}",
+        },
+        {
+            "name": "Rhino 8 Windows",
+            "type": "coreclr",
+            "request": "launch",
+            "targetArchitecture": "x86_64",
+            "program": "C:\\Program Files\\Rhino 8\\System\\Rhino.exe",
+            "cwd": "${workspaceRoot}",
+        }
+    ]
+}

--- a/GhCanvasViewport.csproj
+++ b/GhCanvasViewport.csproj
@@ -1,92 +1,18 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="4.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProductVersion>8.0.30703</ProductVersion>
-    <SchemaVersion>2.0</SchemaVersion>
-    <ProjectGuid>{DECEA083-A800-423C-B7E3-3AD24A1E6186}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>GhCanvasViewport</RootNamespace>
-    <AssemblyName>GhCanvasViewport</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <IsWebBootstrapper>false</IsWebBootstrapper>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
-  </PropertyGroup>
-  <PropertyGroup Condition="'$(Configuration)|$(Platform)' == 'Debug|AnyCPU'">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <CodeAnalysisIgnoreBuiltInRules>false</CodeAnalysisIgnoreBuiltInRules>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
+    <TargetFrameworks>net45;net7.0-windows</TargetFrameworks>
+    <TargetExt>.gha</TargetExt>
+    <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
+    <Deterministic>false</Deterministic>
+    <UseWindowsForms>true</UseWindowsForms>
+    <EnableWindowsTargeting>true</EnableWindowsTargeting>
+    <NoWarn>NU1701</NoWarn>
   </PropertyGroup>
   <ItemGroup>
-    <Reference Include="Eto, Version=2.3.6591.18824, Culture=neutral, PublicKeyToken=552281e97c755530, processorArchitecture=MSIL">
-      <HintPath>packages\RhinoCommon.6.0.18016.23451\lib\net45\Eto.dll</HintPath>
-    </Reference>
-    <Reference Include="Eto.Wpf, Version=2.3.6591.18824, Culture=neutral, PublicKeyToken=552281e97c755530, processorArchitecture=MSIL">
-      <HintPath>packages\RhinoWindows.6.0.18016.23451-test3\lib\net45\Eto.Wpf.dll</HintPath>
-    </Reference>
-    <Reference Include="GH_IO, Version=6.0.18016.23451, Culture=neutral, PublicKeyToken=6a29997d2e6b4f97, processorArchitecture=MSIL">
-      <HintPath>packages\Grasshopper.6.0.18016.23451\lib\net45\GH_IO.dll</HintPath>
-    </Reference>
-    <Reference Include="Grasshopper, Version=6.0.18016.23451, Culture=neutral, PublicKeyToken=dda4f5ec2cd80803, processorArchitecture=MSIL">
-      <HintPath>packages\Grasshopper.6.0.18016.23451\lib\net45\Grasshopper.dll</HintPath>
-    </Reference>
-    <Reference Include="Rhino.UI, Version=6.0.18016.23451, Culture=neutral, PublicKeyToken=552281e97c755530, processorArchitecture=MSIL">
-      <HintPath>packages\RhinoCommon.6.0.18016.23451\lib\net45\Rhino.UI.dll</HintPath>
-    </Reference>
-    <Reference Include="RhinoCommon, Version=6.0.18016.23451, Culture=neutral, PublicKeyToken=552281e97c755530, processorArchitecture=MSIL">
-      <HintPath>packages\RhinoCommon.6.0.18016.23451\lib\net45\RhinoCommon.dll</HintPath>
-    </Reference>
-    <Reference Include="RhinoWindows, Version=6.0.18016.23451, Culture=neutral, PublicKeyToken=552281e97c755530, processorArchitecture=MSIL">
-      <HintPath>packages\RhinoWindows.6.0.18016.23451-test3\lib\net45\RhinoWindows.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Xml" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Drawing" />
-    <Reference Include="System.Windows.Forms" />
+    <PackageReference Include="Grasshopper" Version="6.2.18065.11031" ExcludeAssets="runtime" />
+    <PackageReference Include="RhinoCommon" Version="6.2.18065.11031" ExcludeAssets="runtime" />
+    <PackageReference Include="RhinoWindows" Version="6.2.18065.11031" ExcludeAssets="runtime" />
   </ItemGroup>
-  <ItemGroup>
-    <Compile Include="CanvasViewport.cs" />
-    <Compile Include="CanvasViewportControl.cs">
-      <SubType>Component</SubType>
-    </Compile>
-    <Compile Include="GhCanvasViewportInfo.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
-  <PropertyGroup>
-    <PostBuildEvent>Copy "$(TargetPath)" "$(TargetDir)$(ProjectName).gha"
-Erase "$(TargetPath)"</PostBuildEvent>
-  </PropertyGroup>
   <PropertyGroup>
     <FallbackCulture>en-US</FallbackCulture>
   </PropertyGroup>
@@ -96,13 +22,4 @@ Erase "$(TargetPath)"</PostBuildEvent>
     </StartArguments>
     <StartAction>Program</StartAction>
   </PropertyGroup>
-  <Import Project="packages\RhinoCommon.6.0.18016.23451\build\net45\RhinoCommon.targets" Condition="Exists('packages\RhinoCommon.6.0.18016.23451\build\net45\RhinoCommon.targets')" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
-    <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('packages\RhinoCommon.6.0.18016.23451\build\net45\RhinoCommon.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\RhinoCommon.6.0.18016.23451\build\net45\RhinoCommon.targets'))" />
-    <Error Condition="!Exists('packages\Grasshopper.6.0.18016.23451\build\net45\Grasshopper.targets')" Text="$([System.String]::Format('$(ErrorText)', 'packages\Grasshopper.6.0.18016.23451\build\net45\Grasshopper.targets'))" />
-  </Target>
-  <Import Project="packages\Grasshopper.6.0.18016.23451\build\net45\Grasshopper.targets" Condition="Exists('packages\Grasshopper.6.0.18016.23451\build\net45\Grasshopper.targets')" />
 </Project>

--- a/Properties/launchSettings.json
+++ b/Properties/launchSettings.json
@@ -1,0 +1,22 @@
+{
+  "profiles": {
+    "Rhino 6": {
+      "commandName": "Executable",
+      "executablePath": "C:\\Program Files\\Rhino 6\\System\\Rhino.exe"
+    },
+    "Rhino 7": {
+      "commandName": "Executable",
+      "executablePath": "C:\\Program Files\\Rhino 7\\System\\Rhino.exe"
+    },
+    "Rhino 8 netcore": {
+      "commandName": "Executable",
+      "executablePath": "C:\\Program Files\\Rhino 8\\System\\Rhino.exe",
+      "commandLineArgs": "/netcore"
+    },
+    "Rhino 8 netfx": {
+      "commandName": "Executable",
+      "executablePath": "C:\\Program Files\\Rhino 8\\System\\Rhino.exe",
+      "commandLineArgs": "/netfx"
+    }
+  }
+}

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,10 +1,10 @@
 version: '{build}'
-image: Visual Studio 2019
+image: Visual Studio 2022
 configuration: Release
 
 environment:
   # set version number for plug-in and yak package
-  assembly_version: 1.0.1
+  assembly_version: 1.0.2
   yak_package_version: $(assembly_version)
 
   # set auth token for yak
@@ -30,7 +30,7 @@ build:
 before_deploy:
   - curl -fSLo yak.exe https://files.mcneel.com/yak/tools/latest/yak.exe
     && yak.exe version
-    && copy bin\GhCanvasViewport.gha dist
+    && copy bin\Release\net45\GhCanvasViewport.gha dist
     && cd dist
     && ..\yak.exe build --version "%yak_package_version%" --platform win
     && cd ..

--- a/packages.config
+++ b/packages.config
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Grasshopper" version="6.0.18016.23451" targetFramework="net45" />
-  <package id="RhinoCommon" version="6.0.18016.23451" targetFramework="net45" />
-  <package id="RhinoWindows" version="6.0.18016.23451-test3" targetFramework="net45" />
-</packages>


### PR DESCRIPTION
- Update .csproj to SDK style
- Use ToolStripMenuItem/ContextMenuStrip vs MenuItem/ContextMenu
- Build for .NET 7 to allow for debugging and catch API errors